### PR TITLE
Add calendar page with events

### DIFF
--- a/app/(components)/ModalForm.js
+++ b/app/(components)/ModalForm.js
@@ -25,6 +25,7 @@ export default function ModalForm() {
         description: '',
         destination: '',
         date: '',
+        duration: 1,
         budget: 0,
         image: ''
       });
@@ -123,6 +124,10 @@ export default function ModalForm() {
                 <FormControl>
                     <FormLabel>Date</FormLabel>
                     <Input type="date" name="date" value={formData.date} onChange={handleChange} required />
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Duration (days)</FormLabel>
+                    <Input type="number" name="duration" min="1" value={formData.duration} onChange={handleChange} required />
                 </FormControl>
                 <FormControl>
                     <FormLabel>Budget(CHF)</FormLabel>

--- a/app/(components)/ModalForm.js
+++ b/app/(components)/ModalForm.js
@@ -24,6 +24,7 @@ export default function ModalForm() {
         title: '',
         description: '',
         destination: '',
+        date: '',
         budget: 0,
         image: ''
       });
@@ -118,6 +119,10 @@ export default function ModalForm() {
                 <FormControl>
                     <FormLabel>Destination</FormLabel>
                     <Input name="destination" value={formData.destination} onChange={handleChange} required />
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Date</FormLabel>
+                    <Input type="date" name="date" value={formData.date} onChange={handleChange} required />
                 </FormControl>
                 <FormControl>
                     <FormLabel>Budget(CHF)</FormLabel>

--- a/app/(components)/Navbar.js
+++ b/app/(components)/Navbar.js
@@ -2,6 +2,9 @@
 import Box from '@mui/joy/Box';
 import Typography from '@mui/joy/Typography';
 import DarkModeButton from './DarkModeButton';
+import Link from '@mui/joy/Link';
+import IconButton from '@mui/joy/IconButton';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 
 export default function Navbar () {
 
@@ -11,7 +14,14 @@ export default function Navbar () {
                     <h1 className=' text-2xl mr-2'> ✈️</h1><Typography level="h3">BusinessTrips</Typography>
                 </div>
 
-                <DarkModeButton/>
+                <div className='flex gap-2'>
+                    <Link href="/calendar" underline='none'>
+                        <IconButton color="neutral">
+                            <CalendarMonthIcon />
+                        </IconButton>
+                    </Link>
+                    <DarkModeButton/>
+                </div>
 
         </Box>
     );

--- a/app/calendar/calendar.css
+++ b/app/calendar/calendar.css
@@ -1,0 +1,25 @@
+.rbc-calendar {
+  background-color: var(--joy-palette-background-body);
+  color: var(--joy-palette-text-primary);
+}
+.rbc-toolbar button {
+  color: var(--joy-palette-text-primary);
+  background-color: var(--joy-palette-background-surface);
+  border: 1px solid var(--joy-palette-divider);
+}
+.rbc-toolbar button.rbc-active,
+.rbc-toolbar button:focus {
+  background-color: var(--joy-palette-background-level1);
+}
+.rbc-event {
+  background-color: var(--joy-palette-primary-solidBg);
+  color: var(--joy-palette-primary-solidColor);
+  border: none;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+.rbc-month-view,
+.rbc-time-view,
+.rbc-agenda-view {
+  background-color: var(--joy-palette-background-surface);
+}

--- a/app/calendar/calendar.css
+++ b/app/calendar/calendar.css
@@ -11,6 +11,15 @@
 .rbc-toolbar button:focus {
   background-color: var(--joy-palette-background-level1);
 }
+.rbc-toolbar {
+  margin-bottom: 8px;
+}
+.rbc-off-range-bg {
+  background-color: var(--joy-palette-background-level1);
+}
+.rbc-today {
+  background-color: var(--joy-palette-primary-softBg);
+}
 .rbc-event {
   background-color: var(--joy-palette-primary-solidBg);
   color: var(--joy-palette-primary-solidColor);

--- a/app/calendar/page.js
+++ b/app/calendar/page.js
@@ -8,8 +8,10 @@ import format from 'date-fns/format';
 import parse from 'date-fns/parse';
 import startOfWeek from 'date-fns/startOfWeek';
 import getDay from 'date-fns/getDay';
+import addDays from 'date-fns/addDays';
 import enUS from 'date-fns/locale/en-US';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
+import './calendar.css';
 
 const locales = { 'en-US': enUS };
 const localizer = dateFnsLocalizer({ format, parse, startOfWeek, getDay, locales });
@@ -30,7 +32,7 @@ export default function CalendarPage() {
         const ev = data.businessTrips.map(trip => ({
           title: trip.title,
           start: new Date(trip.date),
-          end: new Date(trip.date),
+          end: addDays(new Date(trip.date), (trip.duration || 1) - 1),
           allDay: true,
         }));
         setEvents(ev);

--- a/app/calendar/page.js
+++ b/app/calendar/page.js
@@ -1,48 +1,54 @@
-'use client';
-import { useEffect, useState } from 'react';
-import Box from '@mui/joy/Box';
-import CircularProgress from '@mui/joy/CircularProgress';
-import Navbar from '../(components)/Navbar';
-import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
-import format from 'date-fns/format';
-import parse from 'date-fns/parse';
-import startOfWeek from 'date-fns/startOfWeek';
-import getDay from 'date-fns/getDay';
-import addDays from 'date-fns/addDays';
-import enUS from 'date-fns/locale/en-US';
-import IconButton from '@mui/joy/IconButton';
-import ButtonGroup from '@mui/joy/ButtonGroup';
-import Button from '@mui/joy/Button';
-import Typography from '@mui/joy/Typography';
-import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
-import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
-import 'react-big-calendar/lib/css/react-big-calendar.css';
-import './calendar.css';
+"use client";
+import { useEffect, useState } from "react";
+import Box from "@mui/joy/Box";
+import CircularProgress from "@mui/joy/CircularProgress";
+import Navbar from "../(components)/Navbar";
+import { Calendar, dateFnsLocalizer } from "react-big-calendar";
+import format from "date-fns/format";
+import parse from "date-fns/parse";
+import startOfWeek from "date-fns/startOfWeek";
+import getDay from "date-fns/getDay";
+import addDays from "date-fns/addDays";
+import enUS from "date-fns/locale/en-US";
+import IconButton from "@mui/joy/IconButton";
+import ButtonGroup from "@mui/joy/ButtonGroup";
+import Button from "@mui/joy/Button";
+import Typography from "@mui/joy/Typography";
+import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
+import "react-big-calendar/lib/css/react-big-calendar.css";
+import "./calendar.css";
 
-const locales = { 'en-US': enUS };
-const localizer = dateFnsLocalizer({ format, parse, startOfWeek, getDay, locales });
+const locales = { "en-US": enUS };
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek,
+  getDay,
+  locales,
+});
 
 function CustomToolbar({ label, onNavigate, onView, views, view }) {
   return (
-    <Box className='flex justify-between items-center mb-2'>
+    <Box className="flex justify-between items-center mb-2">
       <Box>
-        <IconButton variant='plain' onClick={() => onNavigate('PREV')}>
+        <IconButton variant="plain" onClick={() => onNavigate("PREV")}>
           <ArrowBackIosNewIcon />
         </IconButton>
-        <IconButton variant='plain' onClick={() => onNavigate('TODAY')}>
+        <IconButton variant="plain" onClick={() => onNavigate("TODAY")}>
           <CalendarTodayIcon />
         </IconButton>
-        <IconButton variant='plain' onClick={() => onNavigate('NEXT')}>
+        <IconButton variant="plain" onClick={() => onNavigate("NEXT")}>
           <ArrowForwardIosIcon />
         </IconButton>
       </Box>
-      <Typography level='title-lg'>{label}</Typography>
-      <ButtonGroup size='sm'>
-        {views.map(v => (
+      <Typography level="title-lg">{label}</Typography>
+      <ButtonGroup size="sm">
+        {views.map((v) => (
           <Button
             key={v}
-            variant={v === view ? 'solid' : 'outlined'}
+            variant={v === view ? "solid" : "outlined"}
             onClick={() => onView(v)}
           >
             {v.charAt(0).toUpperCase() + v.slice(1)}
@@ -55,18 +61,19 @@ function CustomToolbar({ label, onNavigate, onView, views, view }) {
 
 export default function CalendarPage() {
   const [events, setEvents] = useState();
-  const [view, setView] = useState('month');
+  const [view, setView] = useState("month");
+  const [date, setDate] = useState(new Date());
 
   useEffect(() => {
-    const lastView = localStorage.getItem('calendarView') || 'month';
+    const lastView = localStorage.getItem("calendarView") || "month";
     setView(lastView);
   }, []);
 
   useEffect(() => {
-    fetch('/api')
-      .then(res => res.json())
-      .then(data => {
-        const ev = data.businessTrips.map(trip => ({
+    fetch("/api")
+      .then((res) => res.json())
+      .then((data) => {
+        const ev = data.businessTrips.map((trip) => ({
           title: trip.title,
           start: new Date(trip.date),
           end: addDays(new Date(trip.date), (trip.duration || 1) - 1),
@@ -76,38 +83,43 @@ export default function CalendarPage() {
       });
   }, []);
 
-  const handleViewChange = v => {
+  const handleViewChange = (v) => {
     setView(v);
-    localStorage.setItem('calendarView', v);
+    localStorage.setItem("calendarView", v);
+  };
+
+  const handleNavigate = (newDate) => {
+    setDate(newDate);
   };
 
   const eventPropGetter = () => ({
     style: {
       borderRadius: 4,
-      backgroundColor: 'var(--joy-palette-primary-solidBg)',
-      color: 'var(--joy-palette-primary-solidColor)',
-      border: 'none',
+      backgroundColor: "var(--joy-palette-primary-solidBg)",
+      color: "var(--joy-palette-primary-solidColor)",
+      border: "none",
     },
   });
 
   return (
-    <Box className='w-full h-screen'>
+    <Box className="w-full h-screen">
       <Navbar />
-      <Box className='p-10 h-[90%]'>
+      <Box className="p-10 h-[90%]">
         {events ? (
           <Calendar
             localizer={localizer}
             events={events}
             view={view}
             onView={handleViewChange}
-            defaultDate={new Date()}
-            views={['month', 'week', 'day']}
+            date={date}
+            onNavigate={handleNavigate}
+            views={["month", "week", "day"]}
             components={{ toolbar: CustomToolbar }}
             eventPropGetter={eventPropGetter}
-            style={{ height: '100%' }}
+            style={{ height: "100%" }}
           />
         ) : (
-          <Box className='w-full h-full flex items-center justify-center'>
+          <Box className="w-full h-full flex items-center justify-center">
             <CircularProgress />
           </Box>
         )}

--- a/app/calendar/page.js
+++ b/app/calendar/page.js
@@ -1,0 +1,65 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Box from '@mui/joy/Box';
+import CircularProgress from '@mui/joy/CircularProgress';
+import Navbar from '../(components)/Navbar';
+import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
+import format from 'date-fns/format';
+import parse from 'date-fns/parse';
+import startOfWeek from 'date-fns/startOfWeek';
+import getDay from 'date-fns/getDay';
+import enUS from 'date-fns/locale/en-US';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+
+const locales = { 'en-US': enUS };
+const localizer = dateFnsLocalizer({ format, parse, startOfWeek, getDay, locales });
+
+export default function CalendarPage() {
+  const [events, setEvents] = useState();
+  const [view, setView] = useState('month');
+
+  useEffect(() => {
+    const lastView = localStorage.getItem('calendarView') || 'month';
+    setView(lastView);
+  }, []);
+
+  useEffect(() => {
+    fetch('/api')
+      .then(res => res.json())
+      .then(data => {
+        const ev = data.businessTrips.map(trip => ({
+          title: trip.title,
+          start: new Date(trip.date),
+          end: new Date(trip.date),
+          allDay: true,
+        }));
+        setEvents(ev);
+      });
+  }, []);
+
+  const handleViewChange = v => {
+    setView(v);
+    localStorage.setItem('calendarView', v);
+  };
+
+  return (
+    <Box className='w-full h-screen'>
+      <Navbar />
+      <Box className='p-10 h-[90%]'>
+        {events ? (
+          <Calendar
+            localizer={localizer}
+            events={events}
+            view={view}
+            onView={handleViewChange}
+            style={{ height: '100%' }}
+          />
+        ) : (
+          <Box className='w-full h-full flex items-center justify-center'>
+            <CircularProgress />
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/app/calendar/page.js
+++ b/app/calendar/page.js
@@ -10,11 +10,48 @@ import startOfWeek from 'date-fns/startOfWeek';
 import getDay from 'date-fns/getDay';
 import addDays from 'date-fns/addDays';
 import enUS from 'date-fns/locale/en-US';
+import IconButton from '@mui/joy/IconButton';
+import ButtonGroup from '@mui/joy/ButtonGroup';
+import Button from '@mui/joy/Button';
+import Typography from '@mui/joy/Typography';
+import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import './calendar.css';
 
 const locales = { 'en-US': enUS };
 const localizer = dateFnsLocalizer({ format, parse, startOfWeek, getDay, locales });
+
+function CustomToolbar({ label, onNavigate, onView, views, view }) {
+  return (
+    <Box className='flex justify-between items-center mb-2'>
+      <Box>
+        <IconButton variant='plain' onClick={() => onNavigate('PREV')}>
+          <ArrowBackIosNewIcon />
+        </IconButton>
+        <IconButton variant='plain' onClick={() => onNavigate('TODAY')}>
+          <CalendarTodayIcon />
+        </IconButton>
+        <IconButton variant='plain' onClick={() => onNavigate('NEXT')}>
+          <ArrowForwardIosIcon />
+        </IconButton>
+      </Box>
+      <Typography level='title-lg'>{label}</Typography>
+      <ButtonGroup size='sm'>
+        {views.map(v => (
+          <Button
+            key={v}
+            variant={v === view ? 'solid' : 'outlined'}
+            onClick={() => onView(v)}
+          >
+            {v.charAt(0).toUpperCase() + v.slice(1)}
+          </Button>
+        ))}
+      </ButtonGroup>
+    </Box>
+  );
+}
 
 export default function CalendarPage() {
   const [events, setEvents] = useState();
@@ -44,6 +81,15 @@ export default function CalendarPage() {
     localStorage.setItem('calendarView', v);
   };
 
+  const eventPropGetter = () => ({
+    style: {
+      borderRadius: 4,
+      backgroundColor: 'var(--joy-palette-primary-solidBg)',
+      color: 'var(--joy-palette-primary-solidColor)',
+      border: 'none',
+    },
+  });
+
   return (
     <Box className='w-full h-screen'>
       <Navbar />
@@ -54,6 +100,10 @@ export default function CalendarPage() {
             events={events}
             view={view}
             onView={handleViewChange}
+            defaultDate={new Date()}
+            views={['month', 'week', 'day']}
+            components={{ toolbar: CustomToolbar }}
+            eventPropGetter={eventPropGetter}
             style={{ height: '100%' }}
           />
         ) : (

--- a/data.json
+++ b/data.json
@@ -89,6 +89,36 @@
       "id": 10,
       "date": "2024-06-10",
       "duration": 2
+    },
+    {
+      "id": 11,
+      "title": "Quartalsmeeting Q2",
+      "description": "Wichtiges Meeting zur Besprechung der Q2-Ergebnisse und Planung für Q3",
+      "destination": "München, Deutschland",
+      "budget": 500,
+      "image": "https://images.unsplash.com/photo-1517048676732-d65bc937f952?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "date": "2025-06-23",
+      "duration": 2
+    },
+    {
+      "id": 12,
+      "title": "Kundentermin - ABC GmbH",
+      "description": "Präsentation der neuen Produktlinie bei unserem Großkunden ABC GmbH",
+      "destination": "Hamburg, Deutschland",
+      "budget": 800,
+      "image": "https://images.unsplash.com/photo-1552664730-d307ca884978?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "date": "2025-06-25",
+      "duration": 1
+    },
+    {
+      "id": 13,
+      "title": "Weiterbildung Digital Marketing",
+      "description": "Seminar über die neuesten Trends im digitalen Marketing",
+      "destination": "Berlin, Deutschland",
+      "budget": 1200,
+      "image": "https://images.unsplash.com/photo-1460925895917-afdab827c52f?q=80&w=2015&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "date": "2025-06-27",
+      "duration": 3
     }
   ]
 }

--- a/data.json
+++ b/data.json
@@ -6,7 +6,8 @@
       "description": "Attending the annual Tech Conference to network and learn about the latest in technology.",
       "destination": "San Francisco, CA",
       "budget": 1300,
-      "image": "https://images.unsplash.com/photo-1546942976-1bdf94ffeb1f?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "image": "https://images.unsplash.com/photo-1546942976-1bdf94ffeb1f?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "date": "2024-05-01"
     },
     {
       "id": 3,
@@ -14,7 +15,8 @@
       "description": "Participating in a workshop to enhance our marketing strategies and tools.",
       "destination": "Chicago, IL",
       "budget": 800,
-      "image": "https://images.unsplash.com/photo-1494522855154-9297ac14b55f?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "image": "https://images.unsplash.com/photo-1494522855154-9297ac14b55f?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "date": "2024-05-05"
     },
     {
       "id": 4,
@@ -22,7 +24,8 @@
       "description": "Presenting our product to the sales team at XYZ Inc.",
       "destination": "Dallas, TX",
       "budget": 1200,
-      "image": "https://images.unsplash.com/photo-1621904878414-d4ca4756bd7e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "image": "https://images.unsplash.com/photo-1621904878414-d4ca4756bd7e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "date": "2024-05-10"
     },
     {
       "id": 5,
@@ -30,7 +33,8 @@
       "description": "A retreat to build teamwork and collaboration within the department.",
       "destination": "Denver, CO",
       "budget": 2000,
-      "image": "https://images.unsplash.com/photo-1612872087720-bb876e2e67d1?q=80&w=1907&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "image": "https://images.unsplash.com/photo-1612872087720-bb876e2e67d1?q=80&w=1907&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "date": "2024-05-15"
     },
     {
       "id": 6,
@@ -38,7 +42,8 @@
       "description": "Exhibiting our products at the International Business Expo.",
       "destination": "Berlin, Germany",
       "budget": 3000,
-      "image": "https://images.unsplash.com/photo-1560969184-10fe8719e047?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "image": "https://images.unsplash.com/photo-1560969184-10fe8719e047?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "date": "2024-05-20"
     },
     {
       "id": 7,
@@ -46,7 +51,8 @@
       "description": "Collaborating with DEF Ltd on a new joint venture.",
       "destination": "London, UK",
       "budget": 2500,
-      "image": "https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "image": "https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "date": "2024-05-25"
     },
     {
       "id": 8,
@@ -54,7 +60,8 @@
       "description": "Hosting an event to launch our new product line.",
       "destination": "Los Angeles, CA",
       "budget": 1800,
-      "image": "https://images.unsplash.com/flagged/photo-1575555201693-7cd442b8023f?q=80&w=1932&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "image": "https://images.unsplash.com/flagged/photo-1575555201693-7cd442b8023f?q=80&w=1932&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      "date": "2024-06-01"
     },
     {
       "title": "Cocktails in Bangkok",
@@ -62,7 +69,8 @@
       "destination": "Bangkok, Thailand",
       "budget": 29000,
       "image": "https://images.unsplash.com/photo-1508009603885-50cf7c579365?q=80&w=2700&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-      "id": 9
+      "id": 9,
+      "date": "2024-06-05"
     },
     {
       "title": "Casino Trip",
@@ -70,7 +78,8 @@
       "destination": "Las Vegas, USA",
       "budget": 81000,
       "image": "https://images.unsplash.com/photo-1587223043646-fa771d9e0c8b?q=80&w=2574&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-      "id": 10
+      "id": 10,
+      "date": "2024-06-10"
     }
   ]
 }

--- a/data.json
+++ b/data.json
@@ -7,7 +7,8 @@
       "destination": "San Francisco, CA",
       "budget": 1300,
       "image": "https://images.unsplash.com/photo-1546942976-1bdf94ffeb1f?q=80&w=2069&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-      "date": "2024-05-01"
+      "date": "2024-05-01",
+      "duration": 2
     },
     {
       "id": 3,
@@ -16,7 +17,8 @@
       "destination": "Chicago, IL",
       "budget": 800,
       "image": "https://images.unsplash.com/photo-1494522855154-9297ac14b55f?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-      "date": "2024-05-05"
+      "date": "2024-05-05",
+      "duration": 1
     },
     {
       "id": 4,
@@ -25,7 +27,8 @@
       "destination": "Dallas, TX",
       "budget": 1200,
       "image": "https://images.unsplash.com/photo-1621904878414-d4ca4756bd7e?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-      "date": "2024-05-10"
+      "date": "2024-05-10",
+      "duration": 3
     },
     {
       "id": 5,
@@ -34,7 +37,8 @@
       "destination": "Denver, CO",
       "budget": 2000,
       "image": "https://images.unsplash.com/photo-1612872087720-bb876e2e67d1?q=80&w=1907&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-      "date": "2024-05-15"
+      "date": "2024-05-15",
+      "duration": 2
     },
     {
       "id": 6,
@@ -43,7 +47,8 @@
       "destination": "Berlin, Germany",
       "budget": 3000,
       "image": "https://images.unsplash.com/photo-1560969184-10fe8719e047?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-      "date": "2024-05-20"
+      "date": "2024-05-20",
+      "duration": 4
     },
     {
       "id": 7,
@@ -52,7 +57,8 @@
       "destination": "London, UK",
       "budget": 2500,
       "image": "https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-      "date": "2024-05-25"
+      "date": "2024-05-25",
+      "duration": 2
     },
     {
       "id": 8,
@@ -61,7 +67,8 @@
       "destination": "Los Angeles, CA",
       "budget": 1800,
       "image": "https://images.unsplash.com/flagged/photo-1575555201693-7cd442b8023f?q=80&w=1932&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-      "date": "2024-06-01"
+      "date": "2024-06-01",
+      "duration": 1
     },
     {
       "title": "Cocktails in Bangkok",
@@ -70,7 +77,8 @@
       "budget": 29000,
       "image": "https://images.unsplash.com/photo-1508009603885-50cf7c579365?q=80&w=2700&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
       "id": 9,
-      "date": "2024-06-05"
+      "date": "2024-06-05",
+      "duration": 3
     },
     {
       "title": "Casino Trip",
@@ -79,7 +87,8 @@
       "budget": 81000,
       "image": "https://images.unsplash.com/photo-1587223043646-fa771d9e0c8b?q=80&w=2574&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
       "id": 10,
-      "date": "2024-06-10"
+      "date": "2024-06-10",
+      "duration": 2
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
         "@mui/joy": "^5.0.0-beta.36",
         "@mui/material": "^5.16.0",
         "@mui/x-charts": "^7.9.0",
+        "date-fns": "^4.1.0",
         "next": "14.2.4",
         "react": "^18",
+        "react-big-calendar": "^1.19.2",
         "react-dom": "^18"
       },
       "devDependencies": {
@@ -1590,6 +1592,18 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@restart/hooks": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
+      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1706,7 +1720,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.5.tgz",
       "integrity": "sha512-piErsCVVbpMMT2r7wbawdZsq4xMvIAhQuac2gedQHysu1TZYEigE6pnFfgZT+/jQnrRuF5r+SHzuehFjfRjr4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1719,6 +1732,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/warning": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
+      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "7.2.0",
@@ -3003,6 +3022,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-arithmetic": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-arithmetic/-/date-arithmetic-4.1.0.tgz",
+      "integrity": "sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg==",
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -3070,6 +3111,15 @@
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/didyoumean": {
@@ -4199,6 +4249,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/globalize": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/globalize/-/globalize-0.1.1.tgz",
+      "integrity": "sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA=="
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -4457,6 +4512,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5112,6 +5176,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5138,6 +5214,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5147,6 +5232,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5203,6 +5294,27 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -5904,6 +6016,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-big-calendar": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-1.19.2.tgz",
+      "integrity": "sha512-2orH+TOXPJBlQGwSl9ZnTK2WZR9OfVf0r1s8mnbpjvtENZfmWHP6nXqxmten1vkvzOMqefVGjh5GurM27HHOZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "clsx": "^1.2.1",
+        "date-arithmetic": "^4.1.0",
+        "dayjs": "^1.11.7",
+        "dom-helpers": "^5.2.1",
+        "globalize": "^0.1.1",
+        "invariant": "^2.2.4",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "luxon": "^3.2.1",
+        "memoize-one": "^6.0.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40",
+        "prop-types": "^15.8.1",
+        "react-overlays": "^5.2.1",
+        "uncontrollable": "^7.2.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-big-calendar/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -5922,6 +6071,32 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
       "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
       "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-overlays": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
+      "integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.8",
+        "@popperjs/core": "^2.11.6",
+        "@restart/hooks": "^0.4.7",
+        "@types/warning": "^3.0.0",
+        "dom-helpers": "^5.2.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.2.1",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
@@ -7068,6 +7243,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uncontrollable": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@types/react": ">=16.9.11",
+        "invariant": "^2.2.4",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.7.2.tgz",
@@ -7148,6 +7338,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "@mui/joy": "^5.0.0-beta.36",
     "@mui/material": "^5.16.0",
     "@mui/x-charts": "^7.9.0",
+    "date-fns": "^4.1.0",
     "next": "14.2.4",
     "react": "^18",
+    "react-big-calendar": "^1.19.2",
     "react-dom": "^18"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add calendar page showing trips in react-big-calendar
- keep calendar view state in localStorage
- link calendar page from the navbar
- extend trip form with a date field
- record trip dates in `data.json`
- install `react-big-calendar` and `date-fns`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ac4b56350832680f525497a4a368d